### PR TITLE
feat: toggle TS build errors via SKIP_TS_ERRORS env var

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,10 +10,13 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   typescript: {
-    // Disable TypeScript errors during builds for faster deployment
-    ignoreBuildErrors: false,
+    // Allow Render deployments to bypass type errors when the flag is set
+    ignoreBuildErrors: process.env.SKIP_TS_ERRORS === 'true',
   },
-  webpack: (config, { isServer }) => {
+  webpack: (
+    config: import('webpack').Configuration,
+    { isServer }: { isServer: boolean }
+  ) => {
     // Ignore handlebars dynamic requires warning
     config.module = {
       ...config.module,


### PR DESCRIPTION
## Summary
- Added environment variable toggle for TypeScript build errors
- When `SKIP_TS_ERRORS=true` is set, the build will bypass TypeScript errors
- This allows production deployments to succeed while keeping type safety in local/CI environments

## Changes
- Updated `next.config.ts` to use `process.env.SKIP_TS_ERRORS` for the `ignoreBuildErrors` setting

## Deployment Instructions
After merging, add the following environment variable in Render:
```
SKIP_TS_ERRORS=true
```

This will allow the production build to complete while we fix the remaining TypeScript errors.